### PR TITLE
feat: change static IP to dynamic from terraform

### DIFF
--- a/ansible/roles/apt_proxy/tasks/main.yml
+++ b/ansible/roles/apt_proxy/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: Set IP of apt proxy
+  set_fact:
+    apt_proxy_host: >-
+      {{ lookup('pipe', 'terraform -chdir=/root/homelab-public/terraform/wieprz output -json')
+         | from_json
+         | json_query('apt_cacher_ip.value') }}
+
 - name: Install detect-http-proxy
   ansible.builtin.template:
     src: detect-http-proxy.j2

--- a/terraform/wieprz/outputs.tf
+++ b/terraform/wieprz/outputs.tf
@@ -1,0 +1,4 @@
+output "apt_cacher_ip" {
+  value = split("/", module.apt-cacher.ip_address)[0]
+}
+


### PR DESCRIPTION
PR replaces static IP from ansible variable with the dynamic one from terraform.
This only need to set up the path in ansible/roles/apt_proxy/tasks/main.yml